### PR TITLE
Add status route for uptime robot monitor

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Ensure there is a simple route for uptime-robot to request.
+  get '/status' => (lambda do |req|
+    [200, {}, ["OK"]]
+  end)
 end


### PR DESCRIPTION
There is an active monitor for the client and a paused monitor for the API.  When a new release is made, let me know and I'll enable the API monitor.