### PR TITLE
Primary groups can be renamed

### DIFF
--- a/client/src/elm/Msg.elm
+++ b/client/src/elm/Msg.elm
@@ -24,7 +24,7 @@ type Msg
     | AddGroupToSecondaryGroup Uuid
     | RemoveGroupFromSecondaryGroup Uuid
     | CreateSecondaryGroup
-    | SetPrimaryGroupName Uuid String
+    | SetPrimaryGroupName Uuid Int String
 
 
 type NodeSpecifier

--- a/client/src/elm/Msg.elm
+++ b/client/src/elm/Msg.elm
@@ -24,6 +24,7 @@ type Msg
     | AddGroupToSecondaryGroup Uuid
     | RemoveGroupFromSecondaryGroup Uuid
     | CreateSecondaryGroup
+    | SetPrimaryGroupName Uuid String
 
 
 type NodeSpecifier

--- a/client/src/elm/Update.elm
+++ b/client/src/elm/Update.elm
@@ -8,6 +8,7 @@ import Form exposing (Form)
 import Form.Field as Field exposing (Field)
 import Forms
 import List.Extra
+import Maybe
 import Model exposing (Model)
 import Msg exposing (..)
 import Node exposing (Node)
@@ -137,6 +138,21 @@ updateInterfaceState msg model =
                 Compute ->
                     -- XXX Handle compute better
                     model
+
+        SetPrimaryGroupName groupId name ->
+            let
+                newPrimaryGroups =
+                    EveryDict.update
+                        groupId
+                        (Maybe.map (\g -> { g | name = name }))
+                        currentBlueprint.clusterPrimaryGroups
+            in
+            { model
+                | currentBlueprint =
+                    { currentBlueprint
+                        | clusterPrimaryGroups = newPrimaryGroups
+                    }
+            }
 
         SetClusterName clusterIndex name ->
             let

--- a/client/src/elm/Update.elm
+++ b/client/src/elm/Update.elm
@@ -7,6 +7,7 @@ import EverySet exposing (EverySet)
 import Form exposing (Form)
 import Form.Field as Field exposing (Field)
 import Forms
+import Forms.Validations as Validations
 import List.Extra
 import Maybe
 import Model exposing (Model)
@@ -139,12 +140,41 @@ updateInterfaceState msg model =
                     -- XXX Handle compute better
                     model
 
-        SetPrimaryGroupName groupId name ->
+        SetPrimaryGroupName groupId clusterIndex name ->
             let
+                updateFn maybeGroup =
+                    case maybeGroup of
+                        Nothing ->
+                            Nothing
+
+                        Just group ->
+                            let
+                                primaryGroups =
+                                    Model.primaryGroupsForCluster model clusterIndex
+
+                                secondaryGroups =
+                                    Model.secondaryGroupsForCluster model clusterIndex
+
+                                stringField =
+                                    Field.string name
+
+                                validationResult =
+                                    Validations.validateGroupName
+                                        primaryGroups
+                                        secondaryGroups
+                                        stringField
+                            in
+                            case validationResult of
+                                Ok name ->
+                                    Just { group | name = name }
+
+                                Err error ->
+                                    Just group
+
                 newPrimaryGroups =
                     EveryDict.update
                         groupId
-                        (Maybe.map (\g -> { g | name = name }))
+                        updateFn
                         currentBlueprint.clusterPrimaryGroups
             in
             { model

--- a/client/src/elm/View.elm
+++ b/client/src/elm/View.elm
@@ -224,7 +224,7 @@ viewCluster model clusterIndex cluster =
 
         primaryGroups =
             Model.primaryGroupsForCluster model clusterIndex
-                |> List.map (viewPrimaryGroup model isFocusedCluster color)
+                |> List.map (viewPrimaryGroup model isFocusedCluster color clusterIndex)
 
         addComputeButton_ =
             addComputeButton isFocusedCluster clusterIndex
@@ -357,8 +357,8 @@ startGroupingButton disabled color clusterIndex =
         (StartCreatingSecondaryGroup clusterIndex)
 
 
-viewPrimaryGroup : Model -> Bool -> Color -> PrimaryGroup -> Html Msg
-viewPrimaryGroup model clusterIsFocused color group =
+viewPrimaryGroup : Model -> Bool -> Color -> Int -> PrimaryGroup -> Html Msg
+viewPrimaryGroup model clusterIsFocused color clusterIndex group =
     let
         nodes =
             PrimaryGroup.nodes group
@@ -368,7 +368,7 @@ viewPrimaryGroup model clusterIsFocused color group =
                 clusterIsFocused
                 color
                 group
-                (SetPrimaryGroupName group.id)
+                (SetPrimaryGroupName group.id clusterIndex)
 
         children =
             List.concat

--- a/client/src/elm/View.elm
+++ b/client/src/elm/View.elm
@@ -363,10 +363,17 @@ viewPrimaryGroup model clusterIsFocused color group =
         nodes =
             PrimaryGroup.nodes group
 
+        groupNameInput =
+            nameInput
+                clusterIsFocused
+                color
+                group
+                (SetPrimaryGroupName group.id)
+
         children =
             List.concat
                 [ [ div []
-                        [ text group.name
+                        [ groupNameInput
                         , removeButton clusterIsFocused <|
                             RemoveComputeGroup group.id
                         ]


### PR DESCRIPTION
This is currently lacking validation of the group name.  We have a validation function that is used when the form is being submitted; it needs plugging in to the rename functionality.